### PR TITLE
Travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.yardoc
+*.pot
+doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker build -t yast-postgresql-image .
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-postgresql-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby
+COPY . /usr/src/app
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 YaST module for learning purposes
 =================================
 
+[![Build Status](https://travis-ci.org/ancorgs/yast-postgresql.svg?branch=master)](
+https://travis-ci.org/ancorgs/yast-postgresql)
+
 A module for [YaST](http://yast.github.io) to manage some PostgreSQL settings,
 developed just to be used with illustrative purposes during [this
 workshop](https://events.opensuse.org/conference/oSC17/program/proposal/1264)


### PR DESCRIPTION
As the plan is also to write some RSpec tests it would be nice to show how the Travis support can be integrated into a new YaST module.

Please enable Travis support for your repository at https://travis-ci.org/profile/ancorgs.

You can see the example log here: https://travis-ci.org/lslezak/yast-postgresql/builds/231134529